### PR TITLE
Update TTL up to 1 year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Update TTL up to 1 year.
+
 ## [1.0.0] - 2018-09-05
 ### Changed
 - Update `CoverResponse` unit test  - add display option

--- a/src/CoverResponse.php
+++ b/src/CoverResponse.php
@@ -37,7 +37,7 @@ class CoverResponse
         $res = new BinaryFileResponse($thumb_path);
         $res->headers->set('Content-type', $provider->getMIMEType());
         if ($use_cache) {
-            $res->setExpires(new \DateTime('+3 months'));
+            $res->setExpires(new \DateTime('+1 year'));
         }
 
         $res->prepare(Request::createFromGlobals());


### PR DESCRIPTION
3개월로 되어있는 표지응답의 TTL을 1년으로 늘렸습니다.

현재 TTL에 의존하지 않고 임의로 캐시를 purge하고 있으며, URL 체계가 바뀌지 않는 한 purge 기능은 유지됩니다.

지금의 3개월이 설정된 특별한 근거가 없으므로 서점의 여타 정적 리소스들과 동일하게 1년으로 맞추어 퍼포먼스 지수를 높이려고 합니다.

https://developers.google.com/web/tools/lighthouse/audits/cache-policy