### PR TITLE
Fix cover thumb path error

### DIFF
--- a/src/BookCoverProvider/AbstractBookCoverProvider.php
+++ b/src/BookCoverProvider/AbstractBookCoverProvider.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Ridibooks\Cover\BookCoverProvider;
 
 use Ridibooks\Cover\Exception\CoverException;
@@ -23,7 +25,7 @@ abstract class AbstractBookCoverProvider
     abstract public function getMIMEType();
 
     /* public for test */
-    public function provide($use_cache = true)
+    public function provide($use_cache = true): ?string
     {
         $source_path = $this->getSourcePath();
 
@@ -44,7 +46,7 @@ abstract class AbstractBookCoverProvider
         return $this->makeCache($cached_cover_path);
     }
 
-    private function getSourcePath()
+    private function getSourcePath(): ?string
     {
         $source_path = $this->file_provider->getSourcePath(
             $this->cover_option_dto->cp_id,
@@ -61,7 +63,7 @@ abstract class AbstractBookCoverProvider
 
     abstract protected function getCacheFilename();
 
-    private function isValid($cached_cover_path)
+    private function isValid($cached_cover_path): bool
     {
         if (!file_exists($cached_cover_path)) {
             return false;
@@ -71,13 +73,14 @@ abstract class AbstractBookCoverProvider
         $source_path = $this->getSourcePath();
         if (filemtime($source_path) - filemtime($cached_cover_path) > 0) {
             @unlink($cached_cover_path);
+
             return false;
         }
 
         return true;
     }
 
-    private function makeCache($output_file_path)
+    private function makeCache($output_file_path): ?string
     {
         $tmp_filename = $this->file_provider->getTempFilePath();
         try {
@@ -114,7 +117,7 @@ abstract class AbstractBookCoverProvider
 
     abstract protected function afterGenerate($new_image, $output_path);
 
-    protected function getCacheFilenamePostfix()
+    protected function getCacheFilenamePostfix(): string
     {
         $postfix = empty($this->cover_option_dto->sub_dir) ? '' : '_' . $this->cover_option_dto->sub_dir;
         $postfix .= ($this->cover_option_dto->color_space === CoverOptions::COLORSPACE_GRAYSCALE) ? '_d' : '';

--- a/src/CoverResponse.php
+++ b/src/CoverResponse.php
@@ -31,7 +31,7 @@ class CoverResponse
             $use_cache = false;
         }
 
-        $thumb_path = $provider->provide($use_cache);
+        $thumb_path = (string)$provider->provide($use_cache);
         if (!is_readable($thumb_path)) {
             return new Response('Cover not found.', Response::HTTP_NOT_FOUND);
         }

--- a/tests/CoverResponseTest.php
+++ b/tests/CoverResponseTest.php
@@ -60,4 +60,15 @@ class CoverResponseTest extends TestCase
 
         $this->assertInstanceOf(Response::class, $response);
     }
+
+    public function testCreateFail()
+    {
+        $b_id = '100000002';
+        $cover_option_dto = CoverOptionDto::import($b_id, null, null, null, null);
+        $file_provider = new TestFileProvider();
+
+        $response = CoverResponse::create('test', $cover_option_dto, $file_provider);
+
+        $this->assertEquals(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+    }
 }


### PR DESCRIPTION
- CoverResponse의 create 함수에서 나던 에러를 수정
    - $thumb_path가 null일 경우 is_readable 함수에서 에러 (string이 아닌 null이 주어져 나는 에러)


- 없는 도서에 대한 요청시 응답이 제대로 오는지에 대해 테스트 추가 (404 응답)