### PR TITLE
CoverOptions 에서 사용하는 default key 를 const 로 셋팅하여 외부에서 참조 가능하도록 함

### DIFF
--- a/src/Options/CoverOptions.php
+++ b/src/Options/CoverOptions.php
@@ -23,28 +23,28 @@ class CoverOptions
     private static $OPTIONS = [
         'size' => [ // size => width
             'small' => 60,
-            'medium' => 80,
+            self::DEFAULT_KEY_SIZE => 80,
             'large' => 110,
             'xlarge' => 150,
             'xxlarge' => 320
         ],
         'dpi' => [ // dpi => scale
             'mdpi' => 1.0,
-            'hdpi' => 1.5,
+            self::DEFAULT_KEY_DPI => 1.5,
             'xhdpi' => 2.0,
             'xxhdpi' => 3.0
         ],
         'format' => [
-            'jpg' => JpgBookCoverProvider::class,
+            self::DEFAULT_KEY_FORMAT => JpgBookCoverProvider::class,
             'png' => PngBookCoverProvider::class,
         ],
         'type' => [ // service_type => subdirectory
-            'service' => self::SUBDIRECTORY_NORMAL,
+            self::DEFAULT_KEY_TYPE => self::SUBDIRECTORY_NORMAL,
             'test' => self::SUBDIRECTORY_TEST
         ],
         'display' => [ // type => colorspace
             'epd' => self::COLORSPACE_GRAYSCALE,
-            'lcd' => self::COLORSPACE_TRUECOLOR,
+            self::DEFAULT_KEY_DISPLAY => self::COLORSPACE_TRUECOLOR,
         ]
     ];
 

--- a/src/Options/CoverOptions.php
+++ b/src/Options/CoverOptions.php
@@ -14,11 +14,11 @@ class CoverOptions
     public const DEFAULT_KEY_TYPE = 'service';
     public const DEFAULT_KEY_DISPLAY = 'lcd';
 
+    public const COLORSPACE_GRAYSCALE = 'grayscale';
+    public const COLORSPACE_TRUECOLOR = 'truecolor';
+
     private const SUBDIRECTORY_NORMAL = '';
     private const SUBDIRECTORY_TEST = 'test';
-
-    private const COLORSPACE_GRAYSCALE = 'grayscale';
-    private const COLORSPACE_TRUECOLOR = 'truecolor';
 
     private static $OPTIONS = [
         'size' => [ // size => width

--- a/src/Options/CoverOptions.php
+++ b/src/Options/CoverOptions.php
@@ -8,11 +8,17 @@ use Ridibooks\Cover\BookCoverProvider\PngBookCoverProvider;
 
 class CoverOptions
 {
-    const SUBDIRECTORY_NORMAL = '';
-    const SUBDIRECTORY_TEST = 'test';
+    public const DEFAULT_KEY_SIZE = 'medium';
+    public const DEFAULT_KEY_DPI = 'hdpi';
+    public const DEFAULT_KEY_FORMAT = 'jpg';
+    public const DEFAULT_KEY_TYPE = 'service';
+    public const DEFAULT_KEY_DISPLAY = 'lcd';
 
-    const COLORSPACE_GRAYSCALE = 'grayscale';
-    const COLORSPACE_TRUECOLOR = 'truecolor';
+    private const SUBDIRECTORY_NORMAL = '';
+    private const SUBDIRECTORY_TEST = 'test';
+
+    private const COLORSPACE_GRAYSCALE = 'grayscale';
+    private const COLORSPACE_TRUECOLOR = 'truecolor';
 
     private static $OPTIONS = [
         'size' => [ // size => width
@@ -51,27 +57,27 @@ class CoverOptions
 
     public static function getWidth($size)
     {
-        return self::get('size', $size, 'medium');
+        return self::get('size', $size, self::DEFAULT_KEY_SIZE);
     }
 
     public static function getScale($dpi): float
     {
-        return self::get('dpi', $dpi, 'hdpi');
+        return self::get('dpi', $dpi, self::DEFAULT_KEY_DPI);
     }
 
     public static function getProviderClass($format): string
     {
-        return self::get('format', $format, 'jpg');
+        return self::get('format', $format, self::DEFAULT_KEY_FORMAT);
     }
 
     public static function getSubdirectory($service_type): string
     {
-        return self::get('type', $service_type, 'service');
+        return self::get('type', $service_type, self::DEFAULT_KEY_TYPE);
     }
 
     public static function getColorspace($display)
     {
-        return self::get('display', $display, 'lcd');
+        return self::get('display', $display, self::DEFAULT_KEY_DISPLAY);
     }
 
     public static function getAvailableSizes(): array


### PR DESCRIPTION
- CoverOptions 에서 default 로 셋팅되는 key 값을 const 로 셋팅하였습니다
  - 표지서비스 개선을 위해 default key를 외부(표지서비스)에서 참조하기 위함입니다 
  - 표지서비스에서 해당 default key 를 통해 람다 서빙용 이미지 파일명을 제너레이트할 예정입니다